### PR TITLE
Convert grunt dependency to a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   ],
   "main": "Gruntfile.js",
   "dependencies": {
-    "grunt": "~0.4.1",
     "wintersmith": "~2.0.5"
+  },
+  "peerDependencies": {
+    "grunt": "~0.4.1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
That's the recommended way of doing things for grunt plugins.
